### PR TITLE
Added an option to analyse a small sample of frames to create a single colour palette for the whole gif

### DIFF
--- a/Moments Recorder/Scripts/Editor/RecorderEditor.cs
+++ b/Moments Recorder/Scripts/Editor/RecorderEditor.cs
@@ -34,6 +34,7 @@ namespace MomentsEditor
 		SerializedProperty m_Width;
 		SerializedProperty m_Height;
 		SerializedProperty m_FramePerSecond;
+		SerializedProperty m_FramesPerColorSample;
 		SerializedProperty m_Repeat;
 		SerializedProperty m_Quality;
 		SerializedProperty m_BufferSize;
@@ -45,6 +46,7 @@ namespace MomentsEditor
 			m_Width = serializedObject.FindProperty("m_Width");
 			m_Height = serializedObject.FindProperty("m_Height");
 			m_FramePerSecond = serializedObject.FindProperty("m_FramePerSecond");
+			m_FramesPerColorSample = serializedObject.FindProperty("m_FramesPerColorSample");
 			m_Repeat = serializedObject.FindProperty("m_Repeat");
 			m_Quality = serializedObject.FindProperty("m_Quality");
 			m_BufferSize = serializedObject.FindProperty("m_BufferSize");
@@ -76,6 +78,7 @@ namespace MomentsEditor
 			EditorGUILayout.PropertyField(m_Quality, new GUIContent("Compression Quality", "Lower values mean better quality but slightly longer processing time. 15 is generally a good middleground value."));
 			EditorGUILayout.PropertyField(m_Repeat, new GUIContent("Repeat", "-1 to disable, 0 to loop indefinitely, >0 to loop a set number of time."));
 			EditorGUILayout.PropertyField(m_FramePerSecond, new GUIContent("Frames Per Second", "The number of frames per second the gif will run at."));
+			EditorGUILayout.PropertyField(m_FramesPerColorSample, new GUIContent("Frames Per Color Sample", "Create the gif's color palette by analysing every n-th frame. Lower values mean better color representation, but much longer processing time. Higher values process faster, but may miss important colors between samples. Zero means a new color palette is created per frame."));
 			EditorGUILayout.PropertyField(m_BufferSize, new GUIContent("Record Time", "The amount of time (in seconds) to record to memory."));
 
 			serializedObject.ApplyModifiedProperties();

--- a/Moments Recorder/Scripts/Gif/GifEncoder.cs
+++ b/Moments Recorder/Scripts/Gif/GifEncoder.cs
@@ -4,10 +4,12 @@
  * 
  * Original code by Kevin Weiner, FM Software.
  * Adapted by Thomas Hourdel.
+ * Extended slightly by Paul Kopetko
  */
 
 using System;
 using System.IO;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Moments.Encoder
@@ -33,6 +35,9 @@ namespace Moments.Encoder
 		protected bool m_IsFirstFrame = true;
 		protected bool m_IsSizeSet = false;           // If false, get size from first frame
 		protected int m_SampleInterval = 10;          // Default sample interval for quantizer
+		protected int m_FramesPerColorSample = 6;	  // Default sample rate (in frames per sample) of color palette
+
+		protected NeuQuant nq;
 
 		/// <summary>
 		/// Default constructor. Repeat will be set to -1 and Quality to 10.
@@ -75,6 +80,50 @@ namespace Moments.Encoder
 		{
 			if (fps > 0f)
 				m_FrameDelay = Mathf.RoundToInt(100f / fps);
+		}
+
+		/// <summary>
+		/// Sets color palette sample rate in frames per sample.
+		/// </summary>
+		/// <param name="fps">Frame rate</param>
+		public void SetFramesPerColorSample(int frames)
+		{
+			m_FramesPerColorSample = frames;
+		}
+
+		/// <summary>
+		/// Builds a colour map out of the combined colours from several frames.
+		/// </summary>
+		/// <param name="frames">List of frames to sample colour palette from</param>
+		public void BuildPalette(ref List<GifFrame> frames) {
+
+			// Do not build the color palette here if user wants separate palettes created per frame
+			if (m_FramesPerColorSample == 0) {
+				return;
+			}
+
+			// Initialize a large image
+			Byte[] combinedPixels = new Byte[3 * frames[0].Width * frames[0].Height * (1 + frames.Count / m_FramesPerColorSample)];
+
+			int count = 0;
+
+			// Stich the large image together out of pixels from several frames
+			for (int i = 0; i < frames.Count; i += m_FramesPerColorSample) {
+				Color32[] p = frames[i].Data;
+				// Texture data is layered down-top, so flip it
+				for (int th = frames[i].Height - 1; th >= 0; th--) {
+					for (int tw = 0; tw < frames[i].Width; tw++) {
+						Color32 color = p[th * frames[i].Width + tw];
+						combinedPixels[count] = color.r; count++;
+						combinedPixels[count] = color.g; count++;
+						combinedPixels[count] = color.b; count++;
+					}
+				}
+			}
+
+			// Run the quantizer over our stitched together image and create reduced palette
+			nq = new NeuQuant(combinedPixels, combinedPixels.Length, (int)m_SampleInterval);
+			m_ColorTab = nq.Process();
 		}
 
 		/// <summary>
@@ -222,14 +271,19 @@ namespace Moments.Encoder
 			}
 		}
 
-		// Analyzes image colors and creates color map.
+		// Maps image colors to the color map
 		protected void AnalyzePixels()
 		{
+
 			int len = m_Pixels.Length;
 			int nPix = len / 3;
 			m_IndexedPixels = new byte[nPix];
-			NeuQuant nq = new NeuQuant(m_Pixels, len, (int)m_SampleInterval);
-			m_ColorTab = nq.Process(); // Create reduced palette
+
+			// Analyze image colors and create color map (original, expensive, Moments Recorder behaviour)
+			if (m_FramesPerColorSample == 0) {
+				nq = new NeuQuant(m_Pixels, len, (int)m_SampleInterval);
+				m_ColorTab = nq.Process(); // Create reduced palette
+			}
 
 			// Map image pixels to new palette
 			int k = 0;

--- a/Moments Recorder/Scripts/Gif/GifEncoder.cs
+++ b/Moments Recorder/Scripts/Gif/GifEncoder.cs
@@ -95,10 +95,12 @@ namespace Moments.Encoder
 		/// Builds a colour map out of the combined colours from several frames.
 		/// </summary>
 		/// <param name="frames">List of frames to sample colour palette from</param>
-		public void BuildPalette(ref List<GifFrame> frames) {
+		public void BuildPalette(ref List<GifFrame> frames)
+		{
 
 			// Do not build the color palette here if user wants separate palettes created per frame
-			if (m_FramesPerColorSample == 0) {
+			if (m_FramesPerColorSample == 0)
+			{
 				return;
 			}
 
@@ -108,11 +110,14 @@ namespace Moments.Encoder
 			int count = 0;
 
 			// Stich the large image together out of pixels from several frames
-			for (int i = 0; i < frames.Count; i += m_FramesPerColorSample) {
+			for (int i = 0; i < frames.Count; i += m_FramesPerColorSample)
+			{
 				Color32[] p = frames[i].Data;
 				// Texture data is layered down-top, so flip it
-				for (int th = frames[i].Height - 1; th >= 0; th--) {
-					for (int tw = 0; tw < frames[i].Width; tw++) {
+				for (int th = frames[i].Height - 1; th >= 0; th--)
+				{
+					for (int tw = 0; tw < frames[i].Width; tw++)
+					{
 						Color32 color = p[th * frames[i].Width + tw];
 						combinedPixels[count] = color.r; count++;
 						combinedPixels[count] = color.g; count++;
@@ -280,7 +285,8 @@ namespace Moments.Encoder
 			m_IndexedPixels = new byte[nPix];
 
 			// Analyze image colors and create color map (original, expensive, Moments Recorder behaviour)
-			if (m_FramesPerColorSample == 0) {
+			if (m_FramesPerColorSample == 0)
+			{
 				nq = new NeuQuant(m_Pixels, len, (int)m_SampleInterval);
 				m_ColorTab = nq.Process(); // Create reduced palette
 			}

--- a/Moments Recorder/Scripts/Recorder.cs
+++ b/Moments Recorder/Scripts/Recorder.cs
@@ -156,6 +156,9 @@ namespace Moments
 		/// 256 colors allowed by the GIF specification). Lower values (minimum = 1) produce better
 		/// colors, but slow processing significantly. Higher values will speed up the quantization
 		/// pass at the cost of lower image quality (maximum = 100).</param>
+		/// <param name="framesPerColorSample">Sample every n-th frame in a recording for color
+		/// mapping purposes. If framesPerColorSample is set to 0, Moments uses its default behaviour
+		/// and creates a brand new color palette every frame.</param>
 		public void Setup(bool autoAspect, int width, int height, int fps, float bufferSize, int repeat, int quality, int framesPerColorSample)
 		{
 			if (State == RecorderState.PreProcessing)

--- a/Moments Recorder/Scripts/Recorder.cs
+++ b/Moments Recorder/Scripts/Recorder.cs
@@ -69,6 +69,9 @@ namespace Moments
 		[SerializeField, Min(0.1f)]
 		float m_BufferSize = 3f;
 
+		[SerializeField, Range(0, 60)]
+		int m_FramesPerColorSample = 6;
+
 		#endregion
 
 		#region Public fields

--- a/Moments Recorder/Scripts/Recorder.cs
+++ b/Moments Recorder/Scripts/Recorder.cs
@@ -156,7 +156,7 @@ namespace Moments
 		/// 256 colors allowed by the GIF specification). Lower values (minimum = 1) produce better
 		/// colors, but slow processing significantly. Higher values will speed up the quantization
 		/// pass at the cost of lower image quality (maximum = 100).</param>
-		public void Setup(bool autoAspect, int width, int height, int fps, float bufferSize, int repeat, int quality)
+		public void Setup(bool autoAspect, int width, int height, int fps, float bufferSize, int repeat, int quality, int framesPerColorSample)
 		{
 			if (State == RecorderState.PreProcessing)
 			{
@@ -178,6 +178,7 @@ namespace Moments
 			m_ReflectionUtils.ConstrainMin(x => x.m_BufferSize, bufferSize);
 			m_ReflectionUtils.ConstrainMin(x => x.m_Repeat, repeat);
 			m_ReflectionUtils.ConstrainRange(x => x.m_Quality, quality);
+			m_ReflectionUtils.ConstrainRange(x => x.m_FramesPerColorSample, framesPerColorSample);
 
 			// Ready to go
 			Init();

--- a/Moments Recorder/Scripts/Worker.cs
+++ b/Moments Recorder/Scripts/Worker.cs
@@ -59,11 +59,13 @@ namespace Moments
 		{
 			m_Encoder.Start(m_FilePath);
 
+			// pass all frames to encoder to build a palette out of a subset of them
+			m_Encoder.BuildPalette(ref m_Frames);
+
 			for (int i = 0; i < m_Frames.Count; i++)
 			{
 				GifFrame frame = m_Frames[i];
 				m_Encoder.AddFrame(frame);
-
 				if (m_OnFileSaveProgress != null)
 				{
 					float percent = (float)i / (float)m_Frames.Count;


### PR DESCRIPTION
I extended Moments for my own project, and I thought other people might find these changes useful, as I get more stable colours and substantially faster encoding time now.

**What Moments does now:**
The existing version of Moments creates a new colour palette for every frame in a gif. NeuQuant is computationally expensive, so this makes encoding slow and, more importantly, it can result in "flickering" colours every frame when the NeuQuant operation quantises the colors slightly differently with a moving camera or changing colors on the screen.

**What my additions do:**
My fork gives Moments the ability to sample several frames from a gif, analyze those frames together with NeuQuant, and create a single color palette that every frame will map to, without further NeuQuant calls.

I've added a "Frames Per Color Sample" field to the inspector, which allows you to sample every n-th frame in a recording for color mapping purposes. If the "Frames Per Color Sample" is set to zero, Moments reverts to its current default behaviour of creating a brand new color palette every frame.

**The results:**
By setting "Frames Per Color Sample" to 6, for instance, I halved the encoding time for my 5.5 second gifs on Windows and I get rock-solid colours for the duration of my gif, without the frame-by-frame flickering I experienced previously.

BEFORE: (please note the flickering pinks and purples on some objects) 
![ultimateultimate-201708271640302424](https://user-images.githubusercontent.com/6477309/29748123-6ba187f4-8b52-11e7-9dd8-bacdd25dfe4c.gif)

AFTER:
![ultimateultimate-201708271643329345](https://user-images.githubusercontent.com/6477309/29748133-9fd06e00-8b52-11e7-91e2-1a19735e7d15.gif)
