### PR TITLE
Update recorder setup to change the height

### DIFF
--- a/Moments Recorder/Scripts/Recorder.cs
+++ b/Moments Recorder/Scripts/Recorder.cs
@@ -168,7 +168,7 @@ namespace Moments
 			m_AutoAspect = autoAspect;
 			m_ReflectionUtils.ConstrainMin(x => x.m_Width, width);
 
-			if (autoAspect)
+			if (!autoAspect)
 				m_ReflectionUtils.ConstrainMin(x => x.m_Height, height);
 
 			m_ReflectionUtils.ConstrainRange(x => x.m_FramePerSecond, fps);


### PR DESCRIPTION
When autoAspect is disable, height should be updated to the value passed to the Setup method, not when autoAspect is enable.