### PR TITLE
Remove texture.Apply call

### DIFF
--- a/Moments Recorder/Scripts/Recorder.cs
+++ b/Moments Recorder/Scripts/Recorder.cs
@@ -429,7 +429,6 @@ namespace Moments
 		{
 			RenderTexture.active = source;
 			target.ReadPixels(new Rect(0, 0, source.width, source.height), 0, 0);
-			target.Apply();
 			RenderTexture.active = null;
 
 			return new GifFrame() { Width = target.width, Height = target.height, Data = target.GetPixels32() };


### PR DESCRIPTION
ReadPixels will put data in the CPU copy of the texture.
Apply will copy the data from the CPU to the GPU.
GetPixels32 will read the data from texture CPU copy into an array.

As you can see, the Apply call is not needed since we're not rendering the texture directly.